### PR TITLE
Refactored contract generation

### DIFF
--- a/src/callEncoder.ts
+++ b/src/callEncoder.ts
@@ -13,6 +13,7 @@ export async function getCallEncoderContract(
   opts: Opts,
   customTypes: TypeDesc[],
   entries: Entry[],
+  palletName: string,
 ) {
   const chain = (await api.rpc.system.chain()).toString();
   const specName = api.runtimeVersion.specName.toString();
@@ -86,17 +87,19 @@ export async function getCallEncoderContract(
     );
   }
 
+  const contractLibName = `${palletName}CallEncoder`;
+
   const callEncodersContract = `// Auto-generated from ${chain} (${specName} v${specVersion})
 // Source WS: ${opts.ws}
 pragma solidity ^0.8.24;
 
 import "./ScaleCodec.sol";
-import "./${sanitize(opts.contract)}.sol";
+import "./${contractLibName}.sol";
 
 ${customCodecs.join('\n')}
 
 /// @title Typed SCALE encoders for selected calls (supported classified args only)
-library ${sanitize(opts.contract)} {
+library ${contractLibName} {
 ${encoderFns.join('\n\n')}
 }
     `;

--- a/src/entries/index.ts
+++ b/src/entries/index.ts
@@ -13,11 +13,11 @@ export type Entry = {
   args: ArgDesc[];
 };
 
-export async function getEntries(api: ApiPromise, pallets: string[]): Promise<Entry[]> {
+export async function getEntries(api: ApiPromise, pallet: string): Promise<Entry[]> {
   const entries: Entry[] = [];
 
   for (const [section, sectionMethods] of Object.entries(api.tx)) {
-    if (!pallets.includes(section.toLowerCase())) continue;
+    if (pallet !== section.toLowerCase()) continue;
     for (const [method, extrinsic] of Object.entries(sectionMethods)) {
       const [palletIndex, callIndex] = extrinsic.callIndex as Uint8Array;
 

--- a/src/typeDesc/index.ts
+++ b/src/typeDesc/index.ts
@@ -9,11 +9,11 @@ import {
   resolveTypeName,
 } from './desc';
 
-export function extractAllTypes(api: ApiPromise, pallets: string[]): TypeDesc[] {
+export function extractAllTypes(api: ApiPromise, pallet: string): TypeDesc[] {
   const types: TypeDesc[] = [];
 
   for (const [section, sectionMethods] of Object.entries(api.tx)) {
-    if (!pallets.includes(section.toLowerCase())) continue;
+    if (pallet !== section.toLowerCase()) continue;
 
     for (const [, extrinsic] of Object.entries(sectionMethods as Record<string, any>)) {
       const metaArgs = (extrinsic as any).toJSON().fields;


### PR DESCRIPTION
Shift from a "many-to-one" generation model (many pallets into one file) to a "one-to-one" model (one pallet to one file).
Tests for the generator will be added in a follow-up.