### PR TITLE
Update node_modules cache path in CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,11 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      - name: Cache src/contracts node_modules
+      - name: Cache node_modules
         uses: actions/cache@v4
         with:
-          path: src/contracts/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('src/contracts/package-lock.json') }}
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
 


### PR DESCRIPTION
Changed the cache path from src/contracts/node_modules to node_modules and updated the cache key to use the root package-lock.json.