### PR TITLE
Downgrade Solidity version to 0.8.20 across contracts

### DIFF
--- a/contracts/AssetconversionCallEncoder.sol
+++ b/contracts/AssetconversionCallEncoder.sol
@@ -1,6 +1,6 @@
 // Auto-generated from Westend Asset Hub (westmint v1020000)
 // Source WS: wss://westend-asset-hub-rpc.polkadot.io
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.20;
 
 import "./ScaleCodec.sol";
 import "./AssetconversionCallEncoder.sol";

--- a/contracts/BalancesCallEncoder.sol
+++ b/contracts/BalancesCallEncoder.sol
@@ -1,6 +1,6 @@
 // Auto-generated from Westend Asset Hub (westmint v1020000)
 // Source WS: wss://westend-asset-hub-rpc.polkadot.io
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.20;
 
 import "./ScaleCodec.sol";
 import "./BalancesCallEncoder.sol";

--- a/contracts/ForeignassetsCallEncoder.sol
+++ b/contracts/ForeignassetsCallEncoder.sol
@@ -1,6 +1,6 @@
 // Auto-generated from Westend Asset Hub (westmint v1020000)
 // Source WS: wss://westend-asset-hub-rpc.polkadot.io
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.20;
 
 import "./ScaleCodec.sol";
 import "./ForeignassetsCallEncoder.sol";

--- a/contracts/ScaleCodec.sol
+++ b/contracts/ScaleCodec.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.20;
 
 /// @title Minimal SCALE encoding helpers needed for common FRAME calls
 library ScaleCodec {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -2,7 +2,7 @@ import type { HardhatUserConfig } from "hardhat/config";
 import hardhatToolboxViem from "@nomicfoundation/hardhat-toolbox-viem";
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.24",
+  solidity: "0.8.20",
   plugins: [hardhatToolboxViem],
   paths: { 
     sources: "src/contracts/src/",

--- a/src/callEncoder.ts
+++ b/src/callEncoder.ts
@@ -89,7 +89,7 @@ export async function getCallEncoderContract(
 
   const callEncodersContract = `// Auto-generated from ${chain} (${specName} v${specVersion})
 // Source WS: ${opts.ws}
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.20;
 
 import "./ScaleCodec.sol";
 

--- a/src/contracts/src/BalancesCallEncoderHarness.sol
+++ b/src/contracts/src/BalancesCallEncoderHarness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.20;
 
 import "../../../contracts/BalancesCallEncoder.sol";
 

--- a/src/contracts/src/ScaleCodec.sol
+++ b/src/contracts/src/ScaleCodec.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.20;
 
 /// @title Minimal SCALE encoding helpers needed for common FRAME calls
 library ScaleCodec {

--- a/src/contracts/src/ScaleCodecHarness.sol
+++ b/src/contracts/src/ScaleCodecHarness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.20;
 
 import "./ScaleCodec.sol";
 


### PR DESCRIPTION
Changed the Solidity pragma version from 0.8.24 to 0.8.20 in all relevant contract files, test harnesses, and the Hardhat configuration to ensure consistency and compatibility with the specified compiler version inside polkavm.