### PR TITLE
Refactor complex type handlers and add documentation

### DIFF
--- a/contracts/AssetconversionCallEncoder.sol
+++ b/contracts/AssetconversionCallEncoder.sol
@@ -1,9 +1,8 @@
-// Auto-generated from Westend Asset Hub (westmint v1020000)
+// Auto-generated from Westend Asset Hub (westmint v1020004)
 // Source WS: wss://westend-asset-hub-rpc.polkadot.io
 pragma solidity ^0.8.20;
 
 import "./ScaleCodec.sol";
-import "./AssetconversionCallEncoder.sol";
 
 // Auto-generated from Substrate struct StagingXcmV5Location
 
@@ -43,44 +42,6 @@ library StagingXcmV5JunctionsCodec {
     function encode(StagingXcmV5Junctions memory e) internal pure returns (bytes memory) {
         return bytes.concat(abi.encodePacked(uint8(e.tag)), e.payload);
     }
-
-
-    struct HerePayload {
-            bytes _0;
-        }
-    
-    struct X1Payload {
-            bytes[1] _0;
-        }
-    
-    struct X2Payload {
-            bytes[2] _0;
-        }
-    
-    struct X3Payload {
-            bytes[3] _0;
-        }
-    
-    struct X4Payload {
-            bytes[4] _0;
-        }
-    
-    struct X5Payload {
-            bytes[5] _0;
-        }
-    
-    struct X6Payload {
-            bytes[6] _0;
-        }
-    
-    struct X7Payload {
-            bytes[7] _0;
-        }
-    
-    struct X8Payload {
-            bytes[8] _0;
-        }
-
 
 function Here(bytes _0) internal pure returns (StagingXcmV5Junctions memory e) {
             e.tag = StagingXcmV5JunctionsTag.Here;
@@ -188,52 +149,6 @@ library StagingXcmV5JunctionNetworkIdCodec {
         return bytes.concat(abi.encodePacked(uint8(e.tag)), e.payload);
     }
 
-
-    struct ByGenesisPayload {
-            bytes32 _0;
-        }
-    
-    struct ByForkPayload {
-            bytes _0;
-        }
-    
-    struct PolkadotPayload {
-            bytes _0;
-        }
-    
-    struct KusamaPayload {
-            bytes _0;
-        }
-    
-    struct Unused4Payload {
-            bytes _0;
-        }
-    
-    struct Unused5Payload {
-            bytes _0;
-        }
-    
-    struct Unused6Payload {
-            bytes _0;
-        }
-    
-    struct EthereumPayload {
-            bytes _0;
-        }
-    
-    struct BitcoinCorePayload {
-            bytes _0;
-        }
-    
-    struct BitcoinCashPayload {
-            bytes _0;
-        }
-    
-    struct PolkadotBulletinPayload {
-            bytes _0;
-        }
-
-
 function ByGenesis(bytes32 _0) internal pure returns (StagingXcmV5JunctionNetworkId memory e) {
             e.tag = StagingXcmV5JunctionNetworkIdTag.ByGenesis;
             e.payload = ScaleFixedBytes.encode(bytes32(_0));
@@ -294,7 +209,7 @@ function ByGenesis(bytes32 _0) internal pure returns (StagingXcmV5JunctionNetwor
 /// @title Typed SCALE encoders for selected calls (supported classified args only)
 library AssetconversionCallEncoder {
     /// @notice assetConversion.createPool
-    function assetConversion_createPool(StagingXcmV5Location asset1, StagingXcmV5Location asset2) internal pure returns (bytes memory) {
+    function assetConversion_createPool(StagingXcmV5Location calldata asset1, StagingXcmV5Location calldata asset2) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(56, 0),
             StagingXcmV5LocationCodec.encode(asset1),
@@ -303,7 +218,7 @@ library AssetconversionCallEncoder {
     }
 
     /// @notice assetConversion.addLiquidity
-    function assetConversion_addLiquidity(StagingXcmV5Location asset1, StagingXcmV5Location asset2, uint128 amount1_desired, uint128 amount2_desired, uint128 amount1_min, uint128 amount2_min, bytes32 mint_to) internal pure returns (bytes memory) {
+    function assetConversion_addLiquidity(StagingXcmV5Location calldata asset1, StagingXcmV5Location calldata asset2, uint128 amount1_desired, uint128 amount2_desired, uint128 amount1_min, uint128 amount2_min, bytes32 mint_to) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(56, 1),
             StagingXcmV5LocationCodec.encode(asset1),
@@ -317,7 +232,7 @@ library AssetconversionCallEncoder {
     }
 
     /// @notice assetConversion.removeLiquidity
-    function assetConversion_removeLiquidity(StagingXcmV5Location asset1, StagingXcmV5Location asset2, uint128 lp_token_burn, uint128 amount1_min_receive, uint128 amount2_min_receive, bytes32 withdraw_to) internal pure returns (bytes memory) {
+    function assetConversion_removeLiquidity(StagingXcmV5Location calldata asset1, StagingXcmV5Location calldata asset2, uint128 lp_token_burn, uint128 amount1_min_receive, uint128 amount2_min_receive, bytes32 withdraw_to) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(56, 2),
             StagingXcmV5LocationCodec.encode(asset1),
@@ -330,7 +245,7 @@ library AssetconversionCallEncoder {
     }
 
     /// @notice assetConversion.swapExactTokensForTokens
-    function assetConversion_swapExactTokensForTokens(Vec<StagingXcmV5Location> path, uint128 amount_in, uint128 amount_out_min, bytes32 send_to, bool keep_alive) internal pure returns (bytes memory) {
+    function assetConversion_swapExactTokensForTokens(Vec<StagingXcmV5Location> calldata path, uint128 amount_in, uint128 amount_out_min, bytes32 send_to, bool keep_alive) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(56, 3),
             Vec<StagingXcmV5Location>Codec.encode(path),
@@ -342,7 +257,7 @@ library AssetconversionCallEncoder {
     }
 
     /// @notice assetConversion.swapTokensForExactTokens
-    function assetConversion_swapTokensForExactTokens(Vec<StagingXcmV5Location> path, uint128 amount_out, uint128 amount_in_max, bytes32 send_to, bool keep_alive) internal pure returns (bytes memory) {
+    function assetConversion_swapTokensForExactTokens(Vec<StagingXcmV5Location> calldata path, uint128 amount_out, uint128 amount_in_max, bytes32 send_to, bool keep_alive) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(56, 4),
             Vec<StagingXcmV5Location>Codec.encode(path),
@@ -354,7 +269,7 @@ library AssetconversionCallEncoder {
     }
 
     /// @notice assetConversion.touch
-    function assetConversion_touch(StagingXcmV5Location asset1, StagingXcmV5Location asset2) internal pure returns (bytes memory) {
+    function assetConversion_touch(StagingXcmV5Location calldata asset1, StagingXcmV5Location calldata asset2) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(56, 5),
             StagingXcmV5LocationCodec.encode(asset1),

--- a/contracts/BalancesCallEncoder.sol
+++ b/contracts/BalancesCallEncoder.sol
@@ -1,9 +1,8 @@
-// Auto-generated from Westend Asset Hub (westmint v1020000)
+// Auto-generated from Westend Asset Hub (westmint v1020003)
 // Source WS: wss://westend-asset-hub-rpc.polkadot.io
 pragma solidity ^0.8.20;
 
 import "./ScaleCodec.sol";
-import "./BalancesCallEncoder.sol";
 
 // Auto-generated from Substrate enum PalletBalancesAdjustmentDirection
 

--- a/contracts/BalancesCallEncoder.sol
+++ b/contracts/BalancesCallEncoder.sol
@@ -1,4 +1,4 @@
-// Auto-generated from Westend Asset Hub (westmint v1020003)
+// Auto-generated from Westend Asset Hub (westmint v1020004)
 // Source WS: wss://westend-asset-hub-rpc.polkadot.io
 pragma solidity ^0.8.20;
 
@@ -23,21 +23,15 @@ library PalletBalancesAdjustmentDirectionCodec {
     }
 
 
-    // Increase has no payload
-    
-    // Decrease has no payload
-
-
-
     function Increase() internal pure returns (PalletBalancesAdjustmentDirection memory e) {
       e.tag = PalletBalancesAdjustmentDirectionTag.Increase;
-      e.payload = "";
+      e.payload = new bytes(0);
     }
     
     
     function Decrease() internal pure returns (PalletBalancesAdjustmentDirection memory e) {
       e.tag = PalletBalancesAdjustmentDirectionTag.Decrease;
-      e.payload = "";
+      e.payload = new bytes(0);
     }
 }
 

--- a/contracts/ForeignassetsCallEncoder.sol
+++ b/contracts/ForeignassetsCallEncoder.sol
@@ -1,9 +1,8 @@
-// Auto-generated from Westend Asset Hub (westmint v1020000)
+// Auto-generated from Westend Asset Hub (westmint v1020004)
 // Source WS: wss://westend-asset-hub-rpc.polkadot.io
 pragma solidity ^0.8.20;
 
 import "./ScaleCodec.sol";
-import "./ForeignassetsCallEncoder.sol";
 
 // Auto-generated from Substrate struct StagingXcmV5Location
 
@@ -43,44 +42,6 @@ library StagingXcmV5JunctionsCodec {
     function encode(StagingXcmV5Junctions memory e) internal pure returns (bytes memory) {
         return bytes.concat(abi.encodePacked(uint8(e.tag)), e.payload);
     }
-
-
-    struct HerePayload {
-            bytes _0;
-        }
-    
-    struct X1Payload {
-            bytes[1] _0;
-        }
-    
-    struct X2Payload {
-            bytes[2] _0;
-        }
-    
-    struct X3Payload {
-            bytes[3] _0;
-        }
-    
-    struct X4Payload {
-            bytes[4] _0;
-        }
-    
-    struct X5Payload {
-            bytes[5] _0;
-        }
-    
-    struct X6Payload {
-            bytes[6] _0;
-        }
-    
-    struct X7Payload {
-            bytes[7] _0;
-        }
-    
-    struct X8Payload {
-            bytes[8] _0;
-        }
-
 
 function Here(bytes _0) internal pure returns (StagingXcmV5Junctions memory e) {
             e.tag = StagingXcmV5JunctionsTag.Here;
@@ -188,52 +149,6 @@ library StagingXcmV5JunctionNetworkIdCodec {
         return bytes.concat(abi.encodePacked(uint8(e.tag)), e.payload);
     }
 
-
-    struct ByGenesisPayload {
-            bytes32 _0;
-        }
-    
-    struct ByForkPayload {
-            bytes _0;
-        }
-    
-    struct PolkadotPayload {
-            bytes _0;
-        }
-    
-    struct KusamaPayload {
-            bytes _0;
-        }
-    
-    struct Unused4Payload {
-            bytes _0;
-        }
-    
-    struct Unused5Payload {
-            bytes _0;
-        }
-    
-    struct Unused6Payload {
-            bytes _0;
-        }
-    
-    struct EthereumPayload {
-            bytes _0;
-        }
-    
-    struct BitcoinCorePayload {
-            bytes _0;
-        }
-    
-    struct BitcoinCashPayload {
-            bytes _0;
-        }
-    
-    struct PolkadotBulletinPayload {
-            bytes _0;
-        }
-
-
 function ByGenesis(bytes32 _0) internal pure returns (StagingXcmV5JunctionNetworkId memory e) {
             e.tag = StagingXcmV5JunctionNetworkIdTag.ByGenesis;
             e.payload = ScaleFixedBytes.encode(bytes32(_0));
@@ -294,7 +209,7 @@ function ByGenesis(bytes32 _0) internal pure returns (StagingXcmV5JunctionNetwor
 /// @title Typed SCALE encoders for selected calls (supported classified args only)
 library ForeignassetsCallEncoder {
     /// @notice foreignAssets.create
-    function foreignAssets_create(StagingXcmV5Location id, bytes32 admin, uint128 min_balance) internal pure returns (bytes memory) {
+    function foreignAssets_create(StagingXcmV5Location calldata id, bytes32 admin, uint128 min_balance) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 0),
             StagingXcmV5LocationCodec.encode(id),
@@ -304,7 +219,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.forceCreate
-    function foreignAssets_forceCreate(StagingXcmV5Location id, bytes32 owner, bool is_sufficient, uint128 min_balance) internal pure returns (bytes memory) {
+    function foreignAssets_forceCreate(StagingXcmV5Location calldata id, bytes32 owner, bool is_sufficient, uint128 min_balance) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 1),
             StagingXcmV5LocationCodec.encode(id),
@@ -315,7 +230,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.startDestroy
-    function foreignAssets_startDestroy(StagingXcmV5Location id) internal pure returns (bytes memory) {
+    function foreignAssets_startDestroy(StagingXcmV5Location calldata id) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 2),
             StagingXcmV5LocationCodec.encode(id)
@@ -323,7 +238,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.destroyAccounts
-    function foreignAssets_destroyAccounts(StagingXcmV5Location id) internal pure returns (bytes memory) {
+    function foreignAssets_destroyAccounts(StagingXcmV5Location calldata id) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 3),
             StagingXcmV5LocationCodec.encode(id)
@@ -331,7 +246,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.destroyApprovals
-    function foreignAssets_destroyApprovals(StagingXcmV5Location id) internal pure returns (bytes memory) {
+    function foreignAssets_destroyApprovals(StagingXcmV5Location calldata id) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 4),
             StagingXcmV5LocationCodec.encode(id)
@@ -339,7 +254,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.finishDestroy
-    function foreignAssets_finishDestroy(StagingXcmV5Location id) internal pure returns (bytes memory) {
+    function foreignAssets_finishDestroy(StagingXcmV5Location calldata id) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 5),
             StagingXcmV5LocationCodec.encode(id)
@@ -347,7 +262,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.mint
-    function foreignAssets_mint(StagingXcmV5Location id, bytes32 beneficiary, uint128 amount) internal pure returns (bytes memory) {
+    function foreignAssets_mint(StagingXcmV5Location calldata id, bytes32 beneficiary, uint128 amount) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 6),
             StagingXcmV5LocationCodec.encode(id),
@@ -357,7 +272,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.burn
-    function foreignAssets_burn(StagingXcmV5Location id, bytes32 who, uint128 amount) internal pure returns (bytes memory) {
+    function foreignAssets_burn(StagingXcmV5Location calldata id, bytes32 who, uint128 amount) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 7),
             StagingXcmV5LocationCodec.encode(id),
@@ -367,7 +282,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.transfer
-    function foreignAssets_transfer(StagingXcmV5Location id, bytes32 target, uint128 amount) internal pure returns (bytes memory) {
+    function foreignAssets_transfer(StagingXcmV5Location calldata id, bytes32 target, uint128 amount) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 8),
             StagingXcmV5LocationCodec.encode(id),
@@ -377,7 +292,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.transferKeepAlive
-    function foreignAssets_transferKeepAlive(StagingXcmV5Location id, bytes32 target, uint128 amount) internal pure returns (bytes memory) {
+    function foreignAssets_transferKeepAlive(StagingXcmV5Location calldata id, bytes32 target, uint128 amount) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 9),
             StagingXcmV5LocationCodec.encode(id),
@@ -387,7 +302,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.forceTransfer
-    function foreignAssets_forceTransfer(StagingXcmV5Location id, bytes32 source, bytes32 dest, uint128 amount) internal pure returns (bytes memory) {
+    function foreignAssets_forceTransfer(StagingXcmV5Location calldata id, bytes32 source, bytes32 dest, uint128 amount) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 10),
             StagingXcmV5LocationCodec.encode(id),
@@ -398,7 +313,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.freeze
-    function foreignAssets_freeze(StagingXcmV5Location id, bytes32 who) internal pure returns (bytes memory) {
+    function foreignAssets_freeze(StagingXcmV5Location calldata id, bytes32 who) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 11),
             StagingXcmV5LocationCodec.encode(id),
@@ -407,7 +322,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.thaw
-    function foreignAssets_thaw(StagingXcmV5Location id, bytes32 who) internal pure returns (bytes memory) {
+    function foreignAssets_thaw(StagingXcmV5Location calldata id, bytes32 who) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 12),
             StagingXcmV5LocationCodec.encode(id),
@@ -416,7 +331,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.freezeAsset
-    function foreignAssets_freezeAsset(StagingXcmV5Location id) internal pure returns (bytes memory) {
+    function foreignAssets_freezeAsset(StagingXcmV5Location calldata id) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 13),
             StagingXcmV5LocationCodec.encode(id)
@@ -424,7 +339,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.thawAsset
-    function foreignAssets_thawAsset(StagingXcmV5Location id) internal pure returns (bytes memory) {
+    function foreignAssets_thawAsset(StagingXcmV5Location calldata id) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 14),
             StagingXcmV5LocationCodec.encode(id)
@@ -432,7 +347,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.transferOwnership
-    function foreignAssets_transferOwnership(StagingXcmV5Location id, bytes32 owner) internal pure returns (bytes memory) {
+    function foreignAssets_transferOwnership(StagingXcmV5Location calldata id, bytes32 owner) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 15),
             StagingXcmV5LocationCodec.encode(id),
@@ -441,7 +356,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.setTeam
-    function foreignAssets_setTeam(StagingXcmV5Location id, bytes32 issuer, bytes32 admin, bytes32 freezer) internal pure returns (bytes memory) {
+    function foreignAssets_setTeam(StagingXcmV5Location calldata id, bytes32 issuer, bytes32 admin, bytes32 freezer) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 16),
             StagingXcmV5LocationCodec.encode(id),
@@ -452,7 +367,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.setMetadata
-    function foreignAssets_setMetadata(StagingXcmV5Location id, bytes memory name, bytes memory symbol, uint8 decimals) internal pure returns (bytes memory) {
+    function foreignAssets_setMetadata(StagingXcmV5Location calldata id, bytes memory name, bytes memory symbol, uint8 decimals) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 17),
             StagingXcmV5LocationCodec.encode(id),
@@ -463,7 +378,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.clearMetadata
-    function foreignAssets_clearMetadata(StagingXcmV5Location id) internal pure returns (bytes memory) {
+    function foreignAssets_clearMetadata(StagingXcmV5Location calldata id) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 18),
             StagingXcmV5LocationCodec.encode(id)
@@ -471,7 +386,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.forceSetMetadata
-    function foreignAssets_forceSetMetadata(StagingXcmV5Location id, bytes memory name, bytes memory symbol, uint8 decimals, bool is_frozen) internal pure returns (bytes memory) {
+    function foreignAssets_forceSetMetadata(StagingXcmV5Location calldata id, bytes memory name, bytes memory symbol, uint8 decimals, bool is_frozen) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 19),
             StagingXcmV5LocationCodec.encode(id),
@@ -483,7 +398,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.forceClearMetadata
-    function foreignAssets_forceClearMetadata(StagingXcmV5Location id) internal pure returns (bytes memory) {
+    function foreignAssets_forceClearMetadata(StagingXcmV5Location calldata id) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 20),
             StagingXcmV5LocationCodec.encode(id)
@@ -491,7 +406,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.forceAssetStatus
-    function foreignAssets_forceAssetStatus(StagingXcmV5Location id, bytes32 owner, bytes32 issuer, bytes32 admin, bytes32 freezer, uint128 min_balance, bool is_sufficient, bool is_frozen) internal pure returns (bytes memory) {
+    function foreignAssets_forceAssetStatus(StagingXcmV5Location calldata id, bytes32 owner, bytes32 issuer, bytes32 admin, bytes32 freezer, uint128 min_balance, bool is_sufficient, bool is_frozen) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 21),
             StagingXcmV5LocationCodec.encode(id),
@@ -506,7 +421,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.approveTransfer
-    function foreignAssets_approveTransfer(StagingXcmV5Location id, bytes32 delegate, uint128 amount) internal pure returns (bytes memory) {
+    function foreignAssets_approveTransfer(StagingXcmV5Location calldata id, bytes32 delegate, uint128 amount) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 22),
             StagingXcmV5LocationCodec.encode(id),
@@ -516,7 +431,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.cancelApproval
-    function foreignAssets_cancelApproval(StagingXcmV5Location id, bytes32 delegate) internal pure returns (bytes memory) {
+    function foreignAssets_cancelApproval(StagingXcmV5Location calldata id, bytes32 delegate) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 23),
             StagingXcmV5LocationCodec.encode(id),
@@ -525,7 +440,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.forceCancelApproval
-    function foreignAssets_forceCancelApproval(StagingXcmV5Location id, bytes32 owner, bytes32 delegate) internal pure returns (bytes memory) {
+    function foreignAssets_forceCancelApproval(StagingXcmV5Location calldata id, bytes32 owner, bytes32 delegate) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 24),
             StagingXcmV5LocationCodec.encode(id),
@@ -535,7 +450,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.transferApproved
-    function foreignAssets_transferApproved(StagingXcmV5Location id, bytes32 owner, bytes32 destination, uint128 amount) internal pure returns (bytes memory) {
+    function foreignAssets_transferApproved(StagingXcmV5Location calldata id, bytes32 owner, bytes32 destination, uint128 amount) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 25),
             StagingXcmV5LocationCodec.encode(id),
@@ -546,7 +461,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.touch
-    function foreignAssets_touch(StagingXcmV5Location id) internal pure returns (bytes memory) {
+    function foreignAssets_touch(StagingXcmV5Location calldata id) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 26),
             StagingXcmV5LocationCodec.encode(id)
@@ -554,7 +469,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.refund
-    function foreignAssets_refund(StagingXcmV5Location id, bool allow_burn) internal pure returns (bytes memory) {
+    function foreignAssets_refund(StagingXcmV5Location calldata id, bool allow_burn) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 27),
             StagingXcmV5LocationCodec.encode(id),
@@ -563,7 +478,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.setMinBalance
-    function foreignAssets_setMinBalance(StagingXcmV5Location id, uint128 min_balance) internal pure returns (bytes memory) {
+    function foreignAssets_setMinBalance(StagingXcmV5Location calldata id, uint128 min_balance) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 28),
             StagingXcmV5LocationCodec.encode(id),
@@ -572,7 +487,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.touchOther
-    function foreignAssets_touchOther(StagingXcmV5Location id, bytes32 who) internal pure returns (bytes memory) {
+    function foreignAssets_touchOther(StagingXcmV5Location calldata id, bytes32 who) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 29),
             StagingXcmV5LocationCodec.encode(id),
@@ -581,7 +496,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.refundOther
-    function foreignAssets_refundOther(StagingXcmV5Location id, bytes32 who) internal pure returns (bytes memory) {
+    function foreignAssets_refundOther(StagingXcmV5Location calldata id, bytes32 who) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 30),
             StagingXcmV5LocationCodec.encode(id),
@@ -590,7 +505,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.block
-    function foreignAssets_block(StagingXcmV5Location id, bytes32 who) internal pure returns (bytes memory) {
+    function foreignAssets_block(StagingXcmV5Location calldata id, bytes32 who) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 31),
             StagingXcmV5LocationCodec.encode(id),
@@ -599,7 +514,7 @@ library ForeignassetsCallEncoder {
     }
 
     /// @notice foreignAssets.transferAll
-    function foreignAssets_transferAll(StagingXcmV5Location id, bytes32 dest, bool keep_alive) internal pure returns (bytes memory) {
+    function foreignAssets_transferAll(StagingXcmV5Location calldata id, bytes32 dest, bool keep_alive) internal pure returns (bytes memory) {
         return bytes.concat(
             ScaleCodec.callIndex(53, 32),
             StagingXcmV5LocationCodec.encode(id),

--- a/src/typeDesc/types/enum.ts
+++ b/src/typeDesc/types/enum.ts
@@ -1,14 +1,137 @@
 import { PRIMS, toIdent } from './common';
 
+/**
+ * Generator for Solidity enum definitions and SCALE encoders from Polkadot metadata.
+ * 
+ * Handles Rust enum variants with different payload shapes:
+ * - Unit variants (no data): `enum E { A, B }`
+ * - Tuple variants (anonymous fields): `enum E { A(u32, u64) }`
+ * - Struct variants (named fields): `enum E { A { x: u32, y: u64 } }`
+ * - Mixed variants: `enum E { A, B(u32), C { x: u64 } }`
+ * 
+ * SCALE encoding for enums:
+ * - Discriminant (u8): Variant index (0, 1, 2, ...)
+ * - Payload: SCALE-encoded fields concatenated (if any)
+ * 
+ * Example output:
+ * ```solidity
+ * enum MyEnumTag { VariantA, VariantB }
+ * struct MyEnum { MyEnumTag tag; bytes payload; }
+ * library MyEnumCodec { function encode(...) ... }
+ * ```
+ */
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+/**
+ * Possible shapes for enum variant values in metadata.
+ * - null: Unit variant (no payload)
+ * - number: Explicit discriminant index
+ * - string: Single anonymous field (tuple variant)
+ * - string[]: Multiple anonymous fields (tuple variant)
+ * - Record<string, string>: Named fields (struct variant)
+ * - null: no payload (e.g., enum E { A, B })
+ * - number: custom discriminant index
+ * - string: single unnamed field (tuple variant with one item)
+ * - string[]: multiple unnamed fields (tuple variant)
+ * - Record: named fields (struct-like variant)
+ */
 type VariantShape = null | number | string | string[] | Record<string, string>;
+
+/**
+ * Metadata can provide enum definitions in two formats:
+ * - Array: { _enum: ["A", "B"] } (unit variants only)
+ * - Object: { _enum: { A: null, B: "u32", C: { x: "u64" } } } (complex variants)
+ */
 type EnumJson = { _enum: string[] } | { _enum: Record<string, VariantShape> };
 
-type Field = { name?: string; type: string };
-type Variant = { name: string; index: number; fields: Field[] };
+/**
+ * Represents a field in an enum variant payload.
+ */
+type Field = {
+  /** Field name (lowerCamelCase, optional for tuple variants) */
+  name?: string;
+  /** Rust type reference (e.g., "u128", "Vec<AccountId32>") */
+  type: string;
+};
 
+/**
+ * Represents a parsed enum variant with all metadata.
+ */
+type Variant = {
+  /** Variant name (PascalCase, Solidity-safe) */
+  name: string;
+  /** Discriminant index (0, 1, 2, ...) */
+  index: number;
+  /** Payload fields (empty for unit variants) */
+  fields: Field[];
+};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Regex patterns for Rust type parsing */
+// TODO: Move to shared typeMapping.ts - these patterns are duplicated in struct.ts
+const TYPE_PATTERNS = {
+  VEC: /^Vec<(.+)>$/,
+  BOUNDED_VEC: /^BoundedVec<(.+),(\d+)>$/,
+  FIXED_ARRAY: /^\[(.+);(\d+)\]$/,
+  COMPACT: /^Compact<(.+)>$/,
+  COMPACT_UINT: /^Compact<(u\d+)>$/,
+  OPTION: /^Option<(.+)>$/,
+  U8: /^u8$/,
+} as const;
+
+/** Maximum size for Solidity bytesN types (bytes1 to bytes32) */
+const MAX_SOLIDITY_BYTES_SIZE = 32;
+
+/**
+ * Maps Rust primitive types to their SCALE encoder library names.
+ * Recreated as object to avoid function call overhead in hot path.
+ */
+// TODO: Move to shared typeMapping.ts - encoder name mapping
+const PRIMITIVE_ENCODERS: Record<string, string> = {
+  bool: 'ScaleBool',
+  char: 'ScaleU32', // Rust char is 4 bytes (Unicode scalar value)
+  u8: 'ScaleU8',
+  u16: 'ScaleU16',
+  u32: 'ScaleU32',
+  u64: 'ScaleU64',
+  u128: 'ScaleU128',
+  u256: 'ScaleU256',
+  i8: 'ScaleI8',
+  i16: 'ScaleI16',
+  i32: 'ScaleI32',
+  i64: 'ScaleI64',
+  i128: 'ScaleI128',
+  i256: 'ScaleI256',
+  Bytes: 'ScaleBytes',
+  String: 'ScaleBytes', // String encoded as UTF-8 bytes
+};
+
+// ============================================================================
+// Enum Variant Parsing
+// ============================================================================
+
+/**
+ * Extracts and normalizes enum variants from metadata JSON.
+ * 
+ * Handles two metadata formats:
+ * 1. Array format: { _enum: ["A", "B", "C"] } (unit variants only)
+ * 2. Object format: { _enum: { A: null, B: "u32", C: { x: "u64" } } }
+ * 
+ * Normalizes variant indices to sequential 0..N-1 regardless of
+ * explicit index values in metadata.
+ * 
+ * @param enumDefinition - Enum JSON from metadata
+ * @returns Array of parsed variants sorted by index
+ */
 function extractVariants(def: EnumJson): Variant[] {
+  // Simple enum: just variant names, no payloads
   if (Array.isArray((def as any)._enum)) {
-    // Pure tag enum
     return (def as { _enum: string[] })._enum.map((n, i) => ({
       name: toIdent(n),
       index: i,
@@ -16,44 +139,77 @@ function extractVariants(def: EnumJson): Variant[] {
     }));
   }
 
+  // Complex enum: variants with optional payloads and custom indices
   const raw = (def as { _enum: Record<string, VariantShape> })._enum;
   const entries = Object.entries(raw).map(([k, v], i) => {
     const name = toIdent(k);
     let index: number = i;
     let fields: Field[] = [];
 
+    // Parse variant shape
     if (typeof v === 'number') {
+      // Custom discriminant index
       index = v;
     } else if (v === null) {
+      // No payload
       fields = [];
     } else if (typeof v === 'string') {
+      // Single unnamed field (tuple with one item)
       fields = [{ type: v }];
     } else if (Array.isArray(v)) {
+      // Multiple unnamed fields (tuple)
       fields = v.map((t) => ({ type: t }));
     } else if (typeof v === 'object') {
+      // Named fields (struct-like)
       fields = Object.entries(v).map(([fname, t]) => ({ name: toIdent(fname), type: t }));
     } else {
+      //! Should be clearer: throw new Error(`Unsupported enum variant shape for ${name}: ${JSON.stringify(variantValue)}`);
       throw new Error(`Unsupported enum variant shape for ${name}`);
     }
 
     return { name, index, fields };
   });
 
-  // normalize indices to 0..N-1 in order of "index"
+  //! In Substrate, if metadata says { _enum: { A: 0, B: 5, C: 10 } }, discriminants should be preserved as 0, 5, 10
+  // SCALE requires variants ordered by discriminant, normalized to 0..N-1
   return entries.sort((a, b) => a.index - b.index).map((e, i) => ({ ...e, index: i }));
 }
 
+// ============================================================================
+// Solidity Generation (Main Entry Point)
+// ============================================================================
+
+/**
+ * Generates a complete Solidity enum definition and its SCALE encoder library.
+ * 
+ * SCALE encoding for enums:
+ * - Discriminant: u8 representing variant index (0, 1, 2, ...)
+ * - Payload: SCALE-encoded fields concatenated (if variant has fields)
+ * 
+ * Generated output includes:
+ * - Solidity enum for variant tags (discriminant values)
+ * - Solidity struct combining tag + payload bytes
+ * - Codec library with encode() function and constructor functions for each variant
+ * 
+ * @param typeName - Name of the enum from metadata
+ * @param json - Enum definition (can be pre-parsed object or JSON string)
+ * @returns Complete Solidity code as a string
+ * @throws Error if json is not a valid enum definition
+ */
 export function generateSolidityEnum(typeName: string, json: string | EnumJson): string {
   const def: EnumJson = typeof json === 'string' ? JSON.parse(json) : json;
   if (!('_enum' in def)) throw new Error('Not an enum JSON (missing _enum)');
 
   const enumName = toIdent(typeName);
   const variants = extractVariants(def);
+  
+  //! Missing validation for empty enums,
   const tagName = `${enumName}Tag`;
   const libName = `${enumName}Codec`;
 
   const tagMembers = variants.map((v) => `    ${v.name}`).join(',\n');
 
+  //! These payload structs are generated but never used in the code?
   const payloadStructs = variants
     .map((v) => {
       if (v.fields.length === 0) return `// ${v.name} has no payload`;
@@ -72,6 +228,8 @@ export function generateSolidityEnum(typeName: string, json: string | EnumJson):
   const ctors = variants
     .map((v) => {
       if (v.fields.length === 0) {
+        //! Empty string "" vs actual empty bytes is unclear in Solidity
+        //! Use `new bytes(0)` or `hex""` for clarity
         return `
 function ${v.name}() internal pure returns (${enumName} memory e) {
   e.tag = ${tagName}.${v.name};
@@ -93,6 +251,8 @@ function ${v.name}() internal pure returns (${enumName} memory e) {
     })
     .join('\n\n');
 
+  //! Use bytes1(uint8(e.tag)), same issue as in struct.ts -> https://github.com/argotorg/solidity/issues/10903
+  //! Reference: https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
   return `// Auto-generated from Substrate enum ${typeName}
 
 enum ${tagName} {
@@ -117,126 +277,184 @@ ${ctors.replace(/\n/g, '\n    ')}
 `;
 }
 
-// --- Type mapping ---
-export function solTypeOf(t: string): string {
-  const s = t.replace(/\s+/g, '');
+// ============================================================================
+// Type Mapping Functions
+// ============================================================================
 
-  if (PRIMS[s]) return PRIMS[s];
+/**
+ * Maps a Rust type reference to its Solidity equivalent.
+ * Handles primitives, containers (Vec, arrays), and custom types.
+ * 
+ * SCALE type mapping rules:
+ * - Primitives: Direct mapping (u8 -> uint8, u128 -> uint128, etc.)
+ * - Vec<u8>: Maps to bytes (compact length + raw bytes)
+ * - Vec<T>: Maps to T[] (dynamic array)
+ * - [u8; N] where N <= 32: Maps to bytesN (fixed size)
+ * - [T; N]: Maps to T[N] (fixed-size array)
+ * - Compact<T>: Same Solidity type as T (encoding differs)
+ * - Option<T>: Same Solidity type as T (None/Some handled by encoder)
+ * 
+ * @param rustType - Rust type reference from metadata (e.g., "u128", "Vec<AccountId32>")
+ * @returns Solidity type string
+ * 
+ * @example
+ * solTypeOf("u128") // returns "uint128"
+ * solTypeOf("Vec<u8>") // returns "bytes"
+ * solTypeOf("[u8; 32]") // returns "bytes32"
+ */
+export function solTypeOf(t: string): string {
+  const normalized = t.replace(/\s+/g, '');
+
+  //! TypeScript doesn't guarantee PRIMS[normalized] is defined after this check
+  if (PRIMS[normalized]) return PRIMS[normalized];
 
   // Vec<T> and BoundedVec<T,N>
-  let m = s.match(/^Vec<(.+)>$/);
-  if (m) {
-    const inner = m[1];
-    if (/^u8$/.test(inner)) return 'bytes'; // Vec<u8>
+  let match = normalized.match(TYPE_PATTERNS.VEC);
+  if (match) {
+    const inner = match[1];
+    if (TYPE_PATTERNS.U8.test(inner)) return 'bytes'; // Vec<u8>
     return `${solTypeOf(inner)}[]`;
   }
-  m = s.match(/^BoundedVec<(.+),(\d+)>$/);
-  if (m) {
-    const inner = m[1];
-    if (/^u8$/.test(inner)) return 'bytes'; // BoundedVec<u8,N>
+  match = normalized.match(TYPE_PATTERNS.BOUNDED_VEC);
+  if (match) {
+    const inner = match[1];
+    if (TYPE_PATTERNS.U8.test(inner)) return 'bytes'; // BoundedVec<u8,N>
     return `${solTypeOf(inner)}[]`; // enforce N at encode/decode time
   }
 
   // Fixed-size array [T; N]
-  m = s.match(/^\[(.+);(\d+)\]$/);
-  if (m) {
-    const inner = m[1],
-      N = Number(m[2]);
-    if (/^u8$/.test(inner) && N <= 32) return `bytes${N}`; // SCALE: raw bytes, no length
-    return `${solTypeOf(inner)}[${N}]`;
+  match = normalized.match(TYPE_PATTERNS.FIXED_ARRAY);
+  if (match) {
+    const inner = match[1];
+    const length = Number(match[2]);
+    if (TYPE_PATTERNS.U8.test(inner) && length <= MAX_SOLIDITY_BYTES_SIZE) {
+      return `bytes${length}`; // SCALE: raw bytes, no length prefix
+    }
+    return `${solTypeOf(inner)}[${length}]`;
   }
 
   // Compact<T> maps to the same Solidity numeric type; encoding differs
-  m = s.match(/^Compact<(.+)>$/);
-  if (m) return solTypeOf(m[1]);
+  match = normalized.match(TYPE_PATTERNS.COMPACT);
+  if (match) return solTypeOf(match[1]);
 
-  // Option<T> -> represent as (bool isSome, T value) at the ABI boundary,
-  // or encode-only (leave as T) and handle option in encoder.
-  m = s.match(/^Option<(.+)>$/);
-  if (m) return solTypeOf(m[1]); // for function params; tag handled by encoder
+  // Option<T> -> represent as T in Solidity; None/Some tag handled by encoder
+  match = normalized.match(TYPE_PATTERNS.OPTION);
+  if (match) return solTypeOf(match[1]); // for function params; tag handled by encoder
 
+  //! Consider logging warning or throwing error for truly unknown types to catch metadata bugs early
   // Fallback: treat unknown as bytes
   return 'bytes';
 }
 
-// --- Encoding expression mapping ---
-// Returns a Solidity expression that evaluates to SCALE-encoded bytes for `expr`.
-export function encodeExprOf(expr: string, t: string): string {
-  const s = t.replace(/\s+/g, '');
+// ============================================================================
+// Encoder Expression Generation (TODO: Move to shared typeMapping.ts)
+// ============================================================================
 
-  const prim = {
-    bool: (e: string) => `ScaleBool.encode(${e})`,
-    char: (e: string) => `ScaleU32.encode(${e})`,
-    u8: (e: string) => `ScaleU8.encode(${e})`,
-    u16: (e: string) => `ScaleU16.encode(${e})`,
-    u32: (e: string) => `ScaleU32.encode(${e})`,
-    u64: (e: string) => `ScaleU64.encode(${e})`,
-    u128: (e: string) => `ScaleU128.encode(${e})`,
-    u256: (e: string) => `ScaleU256.encode(${e})`,
-    i8: (e: string) => `ScaleI8.encode(${e})`,
-    i16: (e: string) => `ScaleI16.encode(${e})`,
-    i32: (e: string) => `ScaleI32.encode(${e})`,
-    i64: (e: string) => `ScaleI64.encode(${e})`,
-    i128: (e: string) => `ScaleI128.encode(${e})`,
-    i256: (e: string) => `ScaleI256.encode(${e})`,
-    Bytes: (e: string) => `ScaleBytes.encode(${e})`, // compact len + data
-    String: (e: string) => `ScaleBytes.encode(bytes(${e}))`, // UTF-8 bytes
-  } as Record<string, (e: string) => string>;
-  if (prim[s]) return prim[s](expr);
+/**
+ * Returns a Solidity expression that evaluates to SCALE-encoded bytes for a given value.
+ * Used when generating encoder functions for complex types.
+ * 
+ * SCALE encoding rules:
+ * - Primitives: Call appropriate ScaleXXX.encode() function
+ * - Vec<u8>: ScaleBytes.encode() (compact length + raw bytes)
+ * - Vec<T>: ScaleVec.encode_T() (generated typed encoder)
+ * - [u8; N]: ScaleFixedBytes.encode() (raw bytes, no length prefix)
+ * - [T; N]: ScaleFixedArray.encode_T_N() (generated typed encoder)
+ * - Compact<T>: ScaleCompact.encodeT() (variable-length integer encoding)
+ * - Option<T>: ScaleOption.encode_T() (Some/None tag + optional value)
+ * 
+ * @param expr - Solidity variable name or expression to encode
+ * @param rustType - Rust type reference from metadata
+ * @returns Solidity encoder expression (e.g., "ScaleU128.encode(amount)")
+ * 
+ * @example
+ * encodeExprOf("amount", "u128") // returns "ScaleU128.encode(amount)"
+ * encodeExprOf("data", "Vec<u8>") // returns "ScaleBytes.encode(data)"
+ */
+export function encodeExprOf(expr: string, t: string): string {
+  const normalized = t.replace(/\s+/g, '');
+
+  // Check primitives
+  if (PRIMITIVE_ENCODERS[normalized]) {
+    return `${PRIMITIVE_ENCODERS[normalized]}.encode(${expr})`;
+  }
+
+  //! Rust metadata uses 'String' (capitalized). If lowercase 'string' never appears, remove it
+  //! If it's for Solidity's string type, this should be documented
+  // Special case: String encoded as UTF-8 bytes
+  if (normalized === 'String' || normalized === 'string') {
+    return `ScaleBytes.encode(bytes(${expr}))`; // UTF-8 bytes
+  }
 
   // Vec<T>
-  let m = s.match(/^Vec<(.+)>$/);
-  if (m) {
-    const inner = m[1];
-    if (/^u8$/.test(inner)) return `ScaleBytes.encode(${expr})`; // bytes with compact len
+  let match = normalized.match(TYPE_PATTERNS.VEC);
+  if (match) {
+    const inner = match[1];
+    if (TYPE_PATTERNS.U8.test(inner)) return `ScaleBytes.encode(${expr})`; // bytes with compact len
     // assumes you generate a typed vec encoder for the inner type
-    return `ScaleVec.encode_${mangle(inner)}(${expr})`;
+    return `ScaleVec.encode_${sanitizeTypeForEncoder(inner)}(${expr})`;
   }
 
   // BoundedVec<T, N>
-  m = s.match(/^BoundedVec<(.+),(\d+)>$/);
-  if (m) {
-    const inner = m[1],
-      N = m[2];
-    if (/^u8$/.test(inner)) return `ScaleBytes.encodeBounded(${expr}, ${N})`;
-    return `ScaleVec.encodeBounded_${mangle(inner)}(${expr}, ${N})`;
+  match = normalized.match(TYPE_PATTERNS.BOUNDED_VEC);
+  if (match) {
+    const inner = match[1];
+    const bound = match[2];
+    if (TYPE_PATTERNS.U8.test(inner)) return `ScaleBytes.encodeBounded(${expr}, ${bound})`;
+    return `ScaleVec.encodeBounded_${sanitizeTypeForEncoder(inner)}(${expr}, ${bound})`;
   }
 
   // Fixed-size array [T; N]
-  m = s.match(/^\[(.+);(\d+)\]$/);
-  if (m) {
-    const inner = m[1],
-      N = Number(m[2]);
-    if (/^u8$/.test(inner)) {
+  match = normalized.match(TYPE_PATTERNS.FIXED_ARRAY);
+  if (match) {
+    const inner = match[1];
+    const length = Number(match[2]);
+    if (TYPE_PATTERNS.U8.test(inner)) {
       // SCALE fixed [u8;N] is raw bytes (no length prefix)
-      return N <= 32
-        ? `ScaleFixedBytes.encode(bytes${N}(${expr}))`
+      return length <= MAX_SOLIDITY_BYTES_SIZE
+        ? `ScaleFixedBytes.encode(bytes${length}(${expr}))`
         : `ScaleFixedU8Array.encode(${expr})`; // implement as a loop
     }
-    return `ScaleFixedArray.encode_${mangle(inner)}_${N}(${expr})`;
+    return `ScaleFixedArray.encode_${sanitizeTypeForEncoder(inner)}_${length}(${expr})`;
   }
 
   // Compact<T>
-  m = s.match(/^Compact<(u\d+)>$/);
-  if (m) {
-    const k = m[1].toUpperCase(); // e.g., U32
-    return `ScaleCompact.encode${k}(${expr})`;
+  match = normalized.match(TYPE_PATTERNS.COMPACT_UINT);
+  if (match) {
+    const baseType = match[1].toUpperCase(); // e.g., U32
+    return `ScaleCompact.encode${baseType}(${expr})`;
   }
 
   // Option<T>
-  m = s.match(/^Option<(.+)>$/);
-  if (m) {
-    const inner = m[1];
+  match = normalized.match(TYPE_PATTERNS.OPTION);
+  if (match) {
+    const inner = match[1];
     // Assume you pass a tuple (bool isSome, T val) or have a struct; adjust to your API.
-    return `ScaleOption.encode_${mangle(inner)}(${expr})`;
+    return `ScaleOption.encode_${sanitizeTypeForEncoder(inner)}(${expr})`;
   }
 
+  //! Fallback returns raw expression assuming already-encoded bytes
   // Fallback: assume already-encoded bytes
   return `${expr}`;
 }
 
-// Helper to create suffix-safe names from types, e.g. "u32" -> "U32", "Vec<u32>" -> "Vec_U32"
-function mangle(t: string): string {
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Converts a Rust type reference to a safe identifier for encoder function names.
+ * Handles special characters and nested types to create valid Solidity identifiers.
+ * 
+ * Examples:
+ * - "u32" -> "U32"
+ * - "Vec<u32>" -> "Vec_U32"
+ * - "[AccountId32; 10]" -> "Arr_AccountId32_10"
+ * 
+ * @param rustType - Rust type reference
+ * @returns Sanitized type string safe for use in function names
+ */
+function sanitizeTypeForEncoder(t: string): string {
   return t
     .replace(/\s+/g, '')
     .replace(/\[/g, 'Arr_')

--- a/src/typeDesc/types/enum.ts
+++ b/src/typeDesc/types/enum.ts
@@ -1,4 +1,11 @@
 import { PRIMS, toIdent } from './common';
+import {
+  normalizeType,
+  TYPE_PATTERNS,
+  TYPE_TO_CODEC_NAME,
+  MAX_SOLIDITY_BYTES_SIZE,
+  sanitizeTypeForEncoder,
+} from './typeMapping';
 
 /**
  * Generator for Solidity enum definitions and SCALE encoders from Polkadot metadata.
@@ -73,44 +80,8 @@ type Variant = {
 // Constants
 // ============================================================================
 
-/** Regex patterns for Rust type parsing */
-// TODO: Move to shared typeMapping.ts - these patterns are duplicated in struct.ts
-const TYPE_PATTERNS = {
-  VEC: /^Vec<(.+)>$/,
-  BOUNDED_VEC: /^BoundedVec<(.+),(\d+)>$/,
-  FIXED_ARRAY: /^\[(.+);(\d+)\]$/,
-  COMPACT: /^Compact<(.+)>$/,
-  COMPACT_UINT: /^Compact<(u\d+)>$/,
-  OPTION: /^Option<(.+)>$/,
-  U8: /^u8$/,
-} as const;
-
-/** Maximum size for Solidity bytesN types (bytes1 to bytes32) */
-const MAX_SOLIDITY_BYTES_SIZE = 32;
-
-/**
- * Maps Rust primitive types to their SCALE encoder library names.
- * Recreated as object to avoid function call overhead in hot path.
- */
-// TODO: Move to shared typeMapping.ts - encoder name mapping
-const PRIMITIVE_ENCODERS: Record<string, string> = {
-  bool: 'ScaleBool',
-  char: 'ScaleU32', // Rust char is 4 bytes (Unicode scalar value)
-  u8: 'ScaleU8',
-  u16: 'ScaleU16',
-  u32: 'ScaleU32',
-  u64: 'ScaleU64',
-  u128: 'ScaleU128',
-  u256: 'ScaleU256',
-  i8: 'ScaleI8',
-  i16: 'ScaleI16',
-  i32: 'ScaleI32',
-  i64: 'ScaleI64',
-  i128: 'ScaleI128',
-  i256: 'ScaleI256',
-  Bytes: 'ScaleBytes',
-  String: 'ScaleBytes', // String encoded as UTF-8 bytes
-};
+// Note: TYPE_PATTERNS, MAX_SOLIDITY_BYTES_SIZE, and TYPE_TO_CODEC_NAME 
+// are now imported from ./typeMapping to avoid duplication
 
 // ============================================================================
 // Enum Variant Parsing
@@ -203,37 +174,24 @@ export function generateSolidityEnum(typeName: string, json: string | EnumJson):
   const enumName = toIdent(typeName);
   const variants = extractVariants(def);
   
-  //! Missing validation for empty enums,
+  // Validate enum is not empty
+  if (variants.length === 0) {
+    throw new Error(`Enum ${typeName} has no variants - cannot generate Solidity code for empty enum`);
+  }
+  
   const tagName = `${enumName}Tag`;
   const libName = `${enumName}Codec`;
 
   const tagMembers = variants.map((v) => `    ${v.name}`).join(',\n');
 
-  //! These payload structs are generated but never used in the code?
-  const payloadStructs = variants
-    .map((v) => {
-      if (v.fields.length === 0) return `// ${v.name} has no payload`;
-      const lines = v.fields
-        .map((f, i) => {
-          const solT = solTypeOf(f.type);
-          const fname = f.name ?? `_${i}`;
-          return `        ${solT} ${fname};`;
-        })
-        .join('\n');
-      return `struct ${v.name}Payload {\n${lines}\n    }`;
-    })
-    .join('\n\n');
-
   // Constructors for each variant
   const ctors = variants
     .map((v) => {
       if (v.fields.length === 0) {
-        //! Empty string "" vs actual empty bytes is unclear in Solidity
-        //! Use `new bytes(0)` or `hex""` for clarity
         return `
 function ${v.name}() internal pure returns (${enumName} memory e) {
   e.tag = ${tagName}.${v.name};
-  e.payload = "";
+  e.payload = new bytes(0);
 }`;
       }
       const params = v.fields.map((f, i) => `${solTypeOf(f.type)} ${f.name ?? `_${i}`}`).join(', ');
@@ -270,8 +228,6 @@ library ${libName} {
         return bytes.concat(abi.encodePacked(uint8(e.tag)), e.payload);
     }
 
-${payloadStructs.length ? '\n    ' + payloadStructs.replace(/\n/g, '\n    ') + '\n' : ''}
-
 ${ctors.replace(/\n/g, '\n    ')}
 }
 `;
@@ -303,7 +259,7 @@ ${ctors.replace(/\n/g, '\n    ')}
  * solTypeOf("[u8; 32]") // returns "bytes32"
  */
 export function solTypeOf(t: string): string {
-  const normalized = t.replace(/\s+/g, '');
+  const normalized = normalizeType(t);
 
   //! TypeScript doesn't guarantee PRIMS[normalized] is defined after this check
   if (PRIMS[normalized]) return PRIMS[normalized];
@@ -341,9 +297,8 @@ export function solTypeOf(t: string): string {
   match = normalized.match(TYPE_PATTERNS.OPTION);
   if (match) return solTypeOf(match[1]); // for function params; tag handled by encoder
 
-  //! Consider logging warning or throwing error for truly unknown types to catch metadata bugs early
-  // Fallback: treat unknown as bytes
-  return 'bytes';
+  // Unknown type: throw error to catch metadata bugs early
+  throw new Error(`Cannot map unknown Rust type to Solidity: ${t}`);
 }
 
 // ============================================================================
@@ -372,17 +327,15 @@ export function solTypeOf(t: string): string {
  * encodeExprOf("data", "Vec<u8>") // returns "ScaleBytes.encode(data)"
  */
 export function encodeExprOf(expr: string, t: string): string {
-  const normalized = t.replace(/\s+/g, '');
+  const normalized = normalizeType(t);
 
   // Check primitives
-  if (PRIMITIVE_ENCODERS[normalized]) {
-    return `${PRIMITIVE_ENCODERS[normalized]}.encode(${expr})`;
+  if (TYPE_TO_CODEC_NAME[normalized]) {
+    return `${TYPE_TO_CODEC_NAME[normalized]}.encode(${expr})`;
   }
 
-  //! Rust metadata uses 'String' (capitalized). If lowercase 'string' never appears, remove it
-  //! If it's for Solidity's string type, this should be documented
   // Special case: String encoded as UTF-8 bytes
-  if (normalized === 'String' || normalized === 'string') {
+  if (normalized === 'String') {
     return `ScaleBytes.encode(bytes(${expr}))`; // UTF-8 bytes
   }
 
@@ -433,36 +386,6 @@ export function encodeExprOf(expr: string, t: string): string {
     return `ScaleOption.encode_${sanitizeTypeForEncoder(inner)}(${expr})`;
   }
 
-  //! Fallback returns raw expression assuming already-encoded bytes
-  // Fallback: assume already-encoded bytes
-  return `${expr}`;
-}
-
-// ============================================================================
-// Helper Functions
-// ============================================================================
-
-/**
- * Converts a Rust type reference to a safe identifier for encoder function names.
- * Handles special characters and nested types to create valid Solidity identifiers.
- * 
- * Examples:
- * - "u32" -> "U32"
- * - "Vec<u32>" -> "Vec_U32"
- * - "[AccountId32; 10]" -> "Arr_AccountId32_10"
- * 
- * @param rustType - Rust type reference
- * @returns Sanitized type string safe for use in function names
- */
-function sanitizeTypeForEncoder(t: string): string {
-  return t
-    .replace(/\s+/g, '')
-    .replace(/\[/g, 'Arr_')
-    .replace(/]/g, '')
-    .replace(/;/g, '_')
-    .replace(/</g, '_')
-    .replace(/>/g, '')
-    .replace(/,/g, '_')
-    .replace(/u(\d+)/g, 'U$1')
-    .replace(/i(\d+)/g, 'I$1');
+  // Unknown type: fallback assumes pre-encoded bytes
+  throw new Error(`Cannot generate encoder for unknown Rust type: ${t}`);
 }

--- a/src/typeDesc/types/fixedArray.ts
+++ b/src/typeDesc/types/fixedArray.ts
@@ -1,48 +1,147 @@
-type FixedArraySpec = { _array: { elem: string; len: number } };
+/**
+ * Parser for Rust fixed-size array type syntax from Polkadot metadata.
+ * 
+ * Examples:
+ * - "[u8; 32]" -> { _array: { elem: "u8", len: 32 } }
+ * - "[AccountId32; 10]" -> { _array: { elem: "AccountId32", len: 10 } }
+ * - "[Vec<MyStruct>; 5]" -> { _array: { elem: "Vec<MyStruct>", len: 5 } }
+ * 
+ * Supports both semicolon and comma delimiters: "[T; N]" or "[T, N]".
+ */
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
 
 /**
- * Extract element type and length from a fixed-size array spec.
- * Supports "[T; N]" and "[T, N]". Returns null if not a fixed array.
+ * Parsed fixed-size array specification.
+ * The `_array` wrapper matches the metadata JSON structure.
  */
-export function parseFixedArray(spec: string): FixedArraySpec | null {
-  if (typeof spec !== 'string') return null;
+type FixedArraySpec = { _array: { elem: string; len: number } };
 
-  const s = spec.trim();
-  if (!(s.startsWith('[') && s.endsWith(']'))) return null;
+// ============================================================================
+// Constants
+// ============================================================================
 
-  // strip outer [ ... ]
-  const inner = s.slice(1, -1).trim();
-  if (!inner) return null;
 
-  // Find the top-level delimiter ; or , (not inside <...>, ( ... ), or [ ... ])
-  let angle = 0,
-    round = 0,
-    square = 0,
-    split = -1,
-    delim = '';
-  for (let i = inner.length - 1; i >= 0; i--) {
-    const c = inner[i];
-    if (c === '>') angle++;
-    else if (c === '<') angle--;
-    else if (c === ')') round++;
-    else if (c === '(') round--;
-    else if (c === ']') square++;
-    else if (c === '[') square--;
-    else if ((c === ';' || c === ',') && angle === 0 && round === 0 && square === 0) {
-      split = i;
-      delim = c;
-      break;
+const ARRAY_DELIMITERS = [';', ','] as const;
+
+/** Sentinel value indicating delimiter not found */
+const DELIMITER_NOT_FOUND = -1;
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Finds the index of the top-level delimiter in a fixed-array inner string.
+ * Scans right-to-left to handle nested arrays like "[[u8; 2]; 3]".
+ * Ignores delimiters inside angle brackets <>, parentheses (), or square brackets [].
+ * Valid delimiters between element type and length in array syntax (";", ",")
+ * 
+ * @param innerContent - String between outer brackets (e.g., "u8; 32")
+ * @returns Index of delimiter, or DELIMITER_NOT_FOUND if none found
+ * 
+ * @example
+ * findTopLevelDelimiter("Vec<u8, u16>; 10") // returns 12 (index of ';')
+ */
+function findTopLevelDelimiter(innerContent: string): number {
+  let angleBracketDepth = 0;
+  let roundBracketDepth = 0;
+  let squareBracketDepth = 0;
+  
+  // Scan right-to-left to find the last top-level delimiter
+  // (handles nested arrays like [[u8; 2]; 3] correctly)
+  for (let i = innerContent.length - 1; i >= 0; i--) {
+    const char = innerContent[i];
+    
+    // Track bracket depth to identify top-level delimiters
+    if (char === '>') angleBracketDepth++;
+    else if (char === '<') angleBracketDepth--;
+    else if (char === ')') roundBracketDepth++;
+    else if (char === '(') roundBracketDepth--;
+    else if (char === ']') squareBracketDepth++;
+    else if (char === '[') squareBracketDepth--;
+    else if (
+      (char === ';' || char === ',') &&
+      angleBracketDepth === 0 &&
+      roundBracketDepth === 0 &&
+      squareBracketDepth === 0
+    ) {
+      return i; // Found top-level delimiter
     }
   }
-  if (split < 0) return null;
+  
+  return DELIMITER_NOT_FOUND;
+}
 
-  const left = inner.slice(0, split).trim();
-  const right = inner.slice(split + 1).trim();
-  if (!left || !right) return null;
+// ============================================================================
+// Main Parsing Function
+// ============================================================================
 
-  // length must be an integer
-  const len = Number(right);
-  if (!Number.isInteger(len) || len < 0) return null;
+/**
+ * Parses a Rust fixed-size array type specification into structured form.
+ * 
+ * Supports Rust array syntax:
+ * - "[T; N]" (semicolon delimiter, standard Rust)
+ * - "[T, N]" (comma delimiter, alternate format)
+ * 
+ * Where T is the element type and N is the array length (positive integer).
+ * 
+ * @param spec - Type string from metadata (e.g., "[u8; 32]")
+ * @returns Parsed array spec, or null if not a valid fixed array
+ * 
+ * @example
+ * parseFixedArray("[u8; 32]")
+ * // Returns: { _array: { elem: "u8", len: 32 } }
+ * 
+ * @example
+ * parseFixedArray("[Vec<AccountId32>; 10]")
+ * // Returns: { _array: { elem: "Vec<AccountId32>", len: 10 } }
+ */
+export function parseFixedArray(spec: string): FixedArraySpec | null {
+  // Validate input type
+  if (typeof spec !== 'string') return null;
 
-  return { _array: { elem: left, len } };
+  // Validate Rust array syntax: must be wrapped in brackets
+  const trimmed = spec.trim();
+  if (!(trimmed.startsWith('[') && trimmed.endsWith(']'))) {
+    return null;
+  }
+
+  // Extract content between brackets
+  const innerContent = trimmed.slice(1, -1).trim();
+  if (!innerContent) return null; // Empty brackets: "[]"
+
+  // Find the delimiter separating element type from length
+  const delimiterIndex = findTopLevelDelimiter(innerContent);
+  if (delimiterIndex === DELIMITER_NOT_FOUND) {
+    return null; // No delimiter found
+  }
+
+  // Split into element type and length
+  const elementType = innerContent.slice(0, delimiterIndex).trim();
+  const lengthString = innerContent.slice(delimiterIndex + 1).trim();
+  
+  // Validate both parts exist
+  if (!elementType || !lengthString) {
+    return null; // Missing element type or length
+  }
+
+  // Parse and validate length
+
+  const length = Number(lengthString);
+  if (!Number.isInteger(length) || length < 0 ) {
+    return null; // Length must be a non-negative integer 
+  }
+  
+  //! Either consider fail on array that is too large (|| length > 1024) 
+  //! inside Parse and validate length or Number.MAX_SAFE_INTEGER
+  //! const MAX_ARRAY_LENGTH = 10000; // Reasonable limit for Solidity
+
+  //! if (length > MAX_ARRAY_LENGTH) {
+  //!   return null; // Array too large for practical use
+  //! }
+
+  return { _array: { elem: elementType, len: length } };
 }

--- a/src/typeDesc/types/fixedArray.ts
+++ b/src/typeDesc/types/fixedArray.ts
@@ -131,17 +131,15 @@ export function parseFixedArray(spec: string): FixedArraySpec | null {
   // Parse and validate length
 
   const length = Number(lengthString);
+  const MAX_ARRAY_LENGTH = 10000; // Reasonable limit for Solidity
+
   if (!Number.isInteger(length) || length < 0 ) {
     return null; // Length must be a non-negative integer 
   }
   
-  //! Either consider fail on array that is too large (|| length > 1024) 
-  //! inside Parse and validate length or Number.MAX_SAFE_INTEGER
-  //! const MAX_ARRAY_LENGTH = 10000; // Reasonable limit for Solidity
-
-  //! if (length > MAX_ARRAY_LENGTH) {
-  //!   return null; // Array too large for practical use
-  //! }
+  if (length > MAX_ARRAY_LENGTH) {
+    return null; // Array too large for practical use
+  }
 
   return { _array: { elem: elementType, len: length } };
 }

--- a/src/typeDesc/types/struct.ts
+++ b/src/typeDesc/types/struct.ts
@@ -1,5 +1,34 @@
 import { PRIMS, RESERVED, toIdent } from './common';
 
+/**
+ * Generator for Solidity struct definitions and SCALE encoders from Polkadot metadata.
+ * 
+ * Converts Rust struct definitions from chain metadata into:
+ * - Solidity struct declarations with typed fields
+ * - Codec libraries with SCALE encoding functions
+ * 
+ * Examples of generated code:
+ * 
+ * Input (metadata):
+ *   { "field1": "u128", "field2": "AccountId32" }
+ * 
+ * Output (Solidity):
+ *   struct MyStruct {
+ *       uint128 field1;
+ *       bytes32 field2;
+ *   }
+ *   library MyStructCodec {
+ *       function encode(MyStruct memory s) internal pure returns (bytes memory) {
+ *           return abi.encodePacked(U128Codec.encode(s.field1), AccountId32Codec.encode(s.field2));
+ *       }
+ *   }
+ * 
+ * SCALE encoding rules for structs:
+ * - Fields encoded in declaration order
+ * - No field names or padding
+ * - Simply concatenate encoded field values
+ */
+
 // ============================================================================
 // Type Definitions
 // ============================================================================

--- a/src/typeDesc/types/struct.ts
+++ b/src/typeDesc/types/struct.ts
@@ -1,7 +1,80 @@
 import { PRIMS, RESERVED, toIdent } from './common';
 
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+/**
+ * Metadata can provide struct definitions in two formats:
+ * - Wrapped: { _struct: { field1: "u128", field2: "AccountId32" } }
+ * - Plain:   { field1: "u128", field2: "AccountId32" }
+ */
 type StructShape = { _struct: Record<string, string> } | Record<string, string>;
 
+/**
+ * Represents a parsed struct field with all necessary information
+ * for generating Solidity code.
+ */
+interface StructField {
+  /** Solidity-safe field name (lowerCamelCase) */
+  name: string;
+  /** Original Rust type reference from metadata (e.g., "u128", "Vec<u8>") */
+  typeRef: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Maps Rust primitive/common types to their Solidity codec library names.
+ * Used when generating encoder function calls.
+ */
+const TYPE_TO_CODEC_NAME: Record<string, string> = {
+  u8: 'U8',
+  u16: 'U16',
+  u32: 'U32',
+  u64: 'U64',
+  u128: 'U128',
+  u256: 'U256',
+  i8: 'I8',
+  i16: 'I16',
+  i32: 'I32',
+  i64: 'I64',
+  i128: 'I128',
+  i256: 'I256',
+  bool: 'Bool',
+  H256: 'H256',
+  H160: 'H160',
+  AccountId32: 'AccountId32',
+  Bytes: 'Bytes',
+  String: 'String',
+  string: 'String',
+};
+
+/**
+ * Regex pattern to match Vec<u8> type.
+ * In SCALE, Vec<u8> is encoded as compact length + raw bytes.
+ */
+const VEC_U8_PATTERN = /^Vec<u8>$/;
+
+/**
+ * Regex pattern to match fixed-size byte arrays like [u8; 32].
+ * In SCALE, fixed arrays have no length prefix.
+ */
+const FIXED_U8_ARRAY_PATTERN = /^\[u8;[0-9]+\]$/;
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Validates that the input is a valid struct shape from metadata.
+ * Returns true if the input matches either wrapped or plain struct format.
+ * 
+ * @param x - Value to validate
+ * @returns True if x is a valid StructShape
+ */
 function isStructShape(x: any): x is StructShape {
   if (x && typeof x === 'object' && !Array.isArray(x)) {
     if ('_enum' in x) return false;
@@ -12,76 +85,132 @@ function isStructShape(x: any): x is StructShape {
   return false;
 }
 
+/**
+ * Converts a metadata field name to a valid Solidity field name (lowerCamelCase).
+ * Handles special characters, leading digits, and Solidity reserved words.
+ * 
+ * Examples:
+ * - "my_field" -> "myField"
+ * - "123abc" -> "_123abc"
+ * - "for" -> "for_"
+ * 
+ * @param x - Raw field name from metadata
+ * @returns Solidity-safe lowerCamelCase field name
+ */
 function toVarIdent(x: string): string {
-  // lowerCamelCase, strip non-alphanumerics, avoid leading digits & reserved words
   const cleaned = x.replace(/[^a-zA-Z0-9]+/g, ' ').trim();
-  const parts = cleaned.split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return 'x';
-  const head = parts[0].toLowerCase();
-  const tail = parts.slice(1).map((s) => s[0]?.toUpperCase() + s.slice(1));
-  let out = head + tail.join('');
-  if (/^[0-9]/.test(out)) out = '_' + out;
-  if (RESERVED.has(out)) out = out + '_';
-  return out;
+  const words = cleaned.split(/\s+/).filter(Boolean);
+  
+  if (words.length === 0) return 'x';
+  
+  const firstWord = words[0].toLowerCase();
+  const restWords = words.slice(1).map((s) => s[0]?.toUpperCase() + s.slice(1));
+  let fieldName = firstWord + restWords.join('');
+  
+  // Prefix with underscore if starts with digit
+  if (/^[0-9]/.test(fieldName)) fieldName = '_' + fieldName;
+  
+  // Suffix with underscore if it's a reserved word
+  if (RESERVED.has(fieldName)) fieldName = fieldName + '_';
+  
+  return fieldName;
 }
 
-/** Map registry/alias names to Solidity *field types* used inside the struct. */
+/**
+ * Maps a Rust type reference to its Solidity field type.
+ * Used when generating struct field declarations.
+ * 
+ * SCALE encoding rules:
+ * - Primitives (u8, u128, etc.) map directly to Solidity uintX types
+ * - Vec<u8> maps to bytes (compact length + raw bytes in SCALE)
+ * - [u8; N] maps to bytes (fixed size, no length prefix in SCALE)
+ * - Custom types are assumed to have corresponding Solidity definitions
+ * 
+ * @param typeRef - Rust type reference from metadata (e.g., "u128", "Vec<u8>")
+ * @returns Tuple of [Solidity type, category]
+ */
 function solidityFieldTypeOf(typeRef: string): [string, 'primitive' | 'complex'] {
-  const t = typeRef.replace(/\s+/g, '');
+  //! Duplicate 1 - duplicate normalization logic should be under a single helper function
+  const normalized = typeRef.replace(/\s+/g, ''); 
 
-  if (PRIMS[t]) return [PRIMS[t], 'primitive'];
-  if (/^Vec<u8>$/.test(t)) return ['bytes', 'primitive'];
-  if (/^\[u8;[0-9]+\]$/.test(t)) return ['bytes', 'primitive']; // fixed-size byte-array from metadata → bytes (simplest)
+  if (PRIMS[normalized]) return [PRIMS[normalized], 'primitive'];
+  if (VEC_U8_PATTERN.test(normalized)) return ['bytes', 'primitive'];
+  if (FIXED_U8_ARRAY_PATTERN.test(normalized)) return ['bytes', 'primitive'];
   // Fallback: user-defined type (enum/struct/tuple wrapper). Keep as type name.
   return [toIdent(typeRef), 'complex'];
 }
 
-/** Which codec library to call for a field when encoding. */
+/**
+ * Returns the codec library name for encoding a given Rust type.
+ * Used when generating encoder function calls.
+ * 
+ * Examples:
+ * - "u128" -> "U128" (calls U128Codec.encode)
+ * - "Vec<u8>" -> "Bytes" (calls BytesCodec.encode)
+ * - "MyCustomType" -> "MyCustomType" (calls MyCustomTypeCodec.encode)
+ * 
+ * @param typeRef - Rust type reference from metadata
+ * @returns Codec library name (PascalCase)
+ */
 function codecNameOf(typeRef: string): string {
-  // Normalize a few common aliases so you can implement these codec libs once.
-  const t = typeRef.replace(/\s+/g, '');
-  const ALIASES: Record<string, string> = {
-    u8: 'U8',
-    u16: 'U16',
-    u32: 'U32',
-    u64: 'U64',
-    u128: 'U128',
-    u256: 'U256',
-    i8: 'I8',
-    i16: 'I16',
-    i32: 'I32',
-    i64: 'I64',
-    i128: 'I128',
-    i256: 'I256',
-    bool: 'Bool',
-    H256: 'H256',
-    H160: 'H160',
-    AccountId32: 'AccountId32',
-    Bytes: 'Bytes',
-    String: 'String',
-    string: 'String',
-  };
-  if (ALIASES[t]) return ALIASES[t];
+  const normalized = typeRef.replace(/\s+/g, ''); //! Duplicate 2 (see Duplicate 1)
 
-  if (/^Vec<u8>$/.test(t)) return 'Bytes'; // treat Vec<u8> as Bytes
-  if (/^\[u8;[0-9]+\]$/.test(t)) return 'FixedBytes';
+  // Check if it's a known primitive/common type
+  if (TYPE_TO_CODEC_NAME[normalized]) {
+    return TYPE_TO_CODEC_NAME[normalized];
+  }
+
+  // Check special patterns
+  //! Logic duplication; if we add a new pattern (eg. Vec<u16>), we must update both functions.
+  if (VEC_U8_PATTERN.test(normalized)) return 'Bytes';
+  if (FIXED_U8_ARRAY_PATTERN.test(normalized)) return 'FixedBytes';
 
   // Fallback: user-defined. Use sanitized PascalCase type name.
   return toIdent(typeRef);
 }
 
-function extractStructFields(def: StructShape): { name: string; typeRef: string }[] {
-  const rec = '_struct' in (def as any) ? (def as any)._struct : def;
-  return Object.entries(rec).map(([k, v]) => ({ name: toVarIdent(k), typeRef: v as string }));
+/**
+ * Extracts and parses struct fields from a StructShape definition.
+ * Handles both wrapped and plain metadata formats.
+ * 
+ * @param def - Struct definition from metadata
+ * @returns Array of parsed struct fields with Solidity-safe names
+ */
+function extractStructFields(def: StructShape): StructField[] {
+  //! "def as any" is a poor type modeling defeats TypeScript safety
+  //! proposing additional helper function
+  const fieldsMap = '_struct' in (def as any) ? (def as any)._struct : def;
+  return Object.entries(fieldsMap).map(([k, v]) => ({ name: toVarIdent(k), typeRef: v as string }));
 }
 
+// ============================================================================
+// Main Generation Function
+// ============================================================================
+
+/**
+ * Generates a complete Solidity struct definition and its SCALE encoder library.
+ * 
+ * SCALE encoding for structs:
+ * - Fields are encoded in declaration order
+ * - No field names or padding
+ * - Simply concatenate encoded fields
+ * 
+ * Generated output includes:
+ * - Solidity struct definition with typed fields
+ * - Codec library with encode() function
+ * 
+ * @param typeName - Name of the struct from metadata
+ * @param def - Struct definition (wrapped or plain format)
+ * @returns Complete Solidity code as a string
+ * @throws Error if def is not a valid struct shape
+ */
 export function generateSolidityStruct(typeName: string, def: StructShape): string {
   if (!isStructShape(def))
     throw new Error('Not a struct JSON (expected {_struct:{...}} or plain {field:type})');
 
   const structName = toIdent(typeName);
   const fields = extractStructFields(def);
-
+  //! Unused tuple
   const structBody = fields
     .map(({ name, typeRef }) => {
       return `    ${solidityFieldTypeOf(typeRef)[0]} ${name};`;
@@ -91,7 +220,7 @@ export function generateSolidityStruct(typeName: string, def: StructShape): stri
   const encodeArgs = fields
     .map(({ name, typeRef }) => `${codecNameOf(typeRef)}Codec.encode(s.${name})`)
     .join(', ');
-
+  //! abi.encodePacked - wrong encoding see -> https://github.com/argotorg/solidity/issues/10903
   return `// Auto-generated from Substrate struct ${typeName}
 
 struct ${structName} {

--- a/src/typeDesc/types/struct.ts
+++ b/src/typeDesc/types/struct.ts
@@ -1,4 +1,5 @@
 import { PRIMS, RESERVED, toIdent } from './common';
+import { normalizeType, TYPE_PATTERNS, getCodecName } from './typeMapping';
 
 /**
  * Generator for Solidity struct definitions and SCALE encoders from Polkadot metadata.
@@ -55,43 +56,8 @@ interface StructField {
 // Constants
 // ============================================================================
 
-/**
- * Maps Rust primitive/common types to their Solidity codec library names.
- * Used when generating encoder function calls.
- */
-const TYPE_TO_CODEC_NAME: Record<string, string> = {
-  u8: 'U8',
-  u16: 'U16',
-  u32: 'U32',
-  u64: 'U64',
-  u128: 'U128',
-  u256: 'U256',
-  i8: 'I8',
-  i16: 'I16',
-  i32: 'I32',
-  i64: 'I64',
-  i128: 'I128',
-  i256: 'I256',
-  bool: 'Bool',
-  H256: 'H256',
-  H160: 'H160',
-  AccountId32: 'AccountId32',
-  Bytes: 'Bytes',
-  String: 'String',
-  string: 'String',
-};
-
-/**
- * Regex pattern to match Vec<u8> type.
- * In SCALE, Vec<u8> is encoded as compact length + raw bytes.
- */
-const VEC_U8_PATTERN = /^Vec<u8>$/;
-
-/**
- * Regex pattern to match fixed-size byte arrays like [u8; 32].
- * In SCALE, fixed arrays have no length prefix.
- */
-const FIXED_U8_ARRAY_PATTERN = /^\[u8;[0-9]+\]$/;
+// Note: TYPE_PATTERNS, normalizeType, and getCodecName are now imported 
+// from ./typeMapping to avoid duplication
 
 // ============================================================================
 // Helper Functions
@@ -159,12 +125,11 @@ function toVarIdent(x: string): string {
  * @returns Tuple of [Solidity type, category]
  */
 function solidityFieldTypeOf(typeRef: string): [string, 'primitive' | 'complex'] {
-  //! Duplicate 1 - duplicate normalization logic should be under a single helper function
-  const normalized = typeRef.replace(/\s+/g, ''); 
+  const normalized = normalizeType(typeRef);
 
   if (PRIMS[normalized]) return [PRIMS[normalized], 'primitive'];
-  if (VEC_U8_PATTERN.test(normalized)) return ['bytes', 'primitive'];
-  if (FIXED_U8_ARRAY_PATTERN.test(normalized)) return ['bytes', 'primitive'];
+  if (TYPE_PATTERNS.VEC_U8.test(normalized)) return ['bytes', 'primitive'];
+  if (TYPE_PATTERNS.FIXED_U8_ARRAY.test(normalized)) return ['bytes', 'primitive'];
   // Fallback: user-defined type (enum/struct/tuple wrapper). Keep as type name.
   return [toIdent(typeRef), 'complex'];
 }
@@ -174,26 +139,22 @@ function solidityFieldTypeOf(typeRef: string): [string, 'primitive' | 'complex']
  * Used when generating encoder function calls.
  * 
  * Examples:
- * - "u128" -> "U128" (calls U128Codec.encode)
- * - "Vec<u8>" -> "Bytes" (calls BytesCodec.encode)
+ * - "u128" -> "ScaleU128" (calls ScaleU128Codec.encode)
+ * - "Vec<u8>" -> "ScaleBytes" (calls ScaleBytesCodec.encode)
  * - "MyCustomType" -> "MyCustomType" (calls MyCustomTypeCodec.encode)
  * 
  * @param typeRef - Rust type reference from metadata
  * @returns Codec library name (PascalCase)
  */
 function codecNameOf(typeRef: string): string {
-  const normalized = typeRef.replace(/\s+/g, ''); //! Duplicate 2 (see Duplicate 1)
-
-  // Check if it's a known primitive/common type
-  if (TYPE_TO_CODEC_NAME[normalized]) {
-    return TYPE_TO_CODEC_NAME[normalized];
+  const codecName = getCodecName(typeRef);
+  
+  // If it's a known type from TYPE_TO_CODEC_NAME, it already has "Scale" prefix
+  // For custom types, we need to use the sanitized identifier
+  if (codecName.startsWith('Scale')) {
+    return codecName;
   }
-
-  // Check special patterns
-  //! Logic duplication; if we add a new pattern (eg. Vec<u16>), we must update both functions.
-  if (VEC_U8_PATTERN.test(normalized)) return 'Bytes';
-  if (FIXED_U8_ARRAY_PATTERN.test(normalized)) return 'FixedBytes';
-
+  
   // Fallback: user-defined. Use sanitized PascalCase type name.
   return toIdent(typeRef);
 }

--- a/src/typeDesc/types/typeMapping.ts
+++ b/src/typeDesc/types/typeMapping.ts
@@ -1,0 +1,178 @@
+/**
+ * Shared type mapping utilities for converting Substrate/Polkadot types to Solidity.
+ * 
+ * This module provides common constants, patterns, and helper functions used across
+ * struct.ts and enum.ts to avoid duplication and maintain consistency.
+ */
+
+// ============================================================================
+// Type Normalization
+// ============================================================================
+
+/**
+ * Normalizes a Rust type reference by removing all whitespace.
+ * This ensures consistent type matching regardless of formatting.
+ * 
+ * @param typeRef - Raw type reference that may contain whitespace
+ * @returns Normalized type reference without whitespace
+ * 
+ * @example
+ * normalizeType("Vec < u8 >") // returns "Vec<u8>"
+ * normalizeType("[ u8 ; 32 ]") // returns "[u8;32]"
+ */
+export function normalizeType(typeRef: string): string {
+  return typeRef.replace(/\s+/g, '');
+}
+
+// ============================================================================
+// Type Patterns (Regex)
+// ============================================================================
+
+/**
+ * Regex patterns for matching Rust type structures.
+ * Used across both enum and struct generators for consistent type parsing.
+ */
+export const TYPE_PATTERNS = {
+  /** Matches Vec<T> - dynamic vector type */
+  VEC: /^Vec<(.+)>$/,
+  
+  /** Matches BoundedVec<T,N> - vector with maximum size constraint */
+  BOUNDED_VEC: /^BoundedVec<(.+),(\d+)>$/,
+  
+  /** Matches [T; N] - fixed-size array type */
+  FIXED_ARRAY: /^\[(.+);(\d+)\]$/,
+  
+  /** Matches Compact<T> - compact-encoded integer type */
+  COMPACT: /^Compact<(.+)>$/,
+  
+  /** Matches Compact<uN> - compact-encoded unsigned integer */
+  COMPACT_UINT: /^Compact<(u\d+)>$/,
+  
+  /** Matches Option<T> - optional value type */
+  OPTION: /^Option<(.+)>$/,
+  
+  /** Matches u8 primitive type */
+  U8: /^u8$/,
+  
+  /** Matches Vec<u8> - byte vector (special case for bytes) */
+  VEC_U8: /^Vec<u8>$/,
+  
+  /** Matches [u8; N] - fixed-size byte array */
+  FIXED_U8_ARRAY: /^\[u8;[0-9]+\]$/,
+} as const;
+
+// ============================================================================
+// Codec Name Mappings
+// ============================================================================
+
+/**
+ * Maps Rust primitive/common types to their SCALE codec library names.
+ * Used when generating encoder function calls in both struct and enum generators.
+ * 
+ * Note: This is the merged mapping from both TYPE_TO_CODEC_NAME (struct.ts)
+ * and PRIMITIVE_ENCODERS (enum.ts). The "Scale" prefix convention from enum.ts
+ * is preferred for consistency.
+ */
+export const TYPE_TO_CODEC_NAME: Record<string, string> = {
+  // Boolean
+  bool: 'ScaleBool',
+  
+  // Character (Rust char is 4 bytes - Unicode scalar value)
+  char: 'ScaleU32',
+  
+  // Unsigned integers
+  u8: 'ScaleU8',
+  u16: 'ScaleU16',
+  u32: 'ScaleU32',
+  u64: 'ScaleU64',
+  u128: 'ScaleU128',
+  u256: 'ScaleU256',
+  
+  // Signed integers
+  i8: 'ScaleI8',
+  i16: 'ScaleI16',
+  i32: 'ScaleI32',
+  i64: 'ScaleI64',
+  i128: 'ScaleI128',
+  i256: 'ScaleI256',
+  
+  // Hash types
+  H256: 'ScaleH256',
+  H160: 'ScaleH160',
+  
+  // Account ID
+  AccountId32: 'ScaleAccountId32',
+  
+  // Bytes and strings
+  Bytes: 'ScaleBytes',
+  String: 'ScaleBytes', // String encoded as UTF-8 bytes
+  string: 'ScaleBytes', // lowercase alias
+} as const;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Maximum size for Solidity bytesN types (bytes1 to bytes32) */
+export const MAX_SOLIDITY_BYTES_SIZE = 32;
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Returns the codec library name for encoding a given Rust type.
+ * Used when generating encoder function calls.
+ * 
+ * Handles special cases like Vec<u8> and [u8; N] arrays.
+ * 
+ * @param typeRef - Rust type reference from metadata
+ * @returns Codec library name (with "Scale" prefix)
+ * 
+ * @example
+ * getCodecName("u128") // returns "ScaleU128"
+ * getCodecName("Vec<u8>") // returns "ScaleBytes"
+ * getCodecName("[u8; 32]") // returns "ScaleFixedBytes"
+ * getCodecName("MyCustomType") // returns "MyCustomType" (assumes custom codec exists)
+ */
+export function getCodecName(typeRef: string): string {
+  const normalized = normalizeType(typeRef);
+
+  // Check if it's a known primitive/common type
+  if (TYPE_TO_CODEC_NAME[normalized]) {
+    return TYPE_TO_CODEC_NAME[normalized];
+  }
+
+  // Check special patterns
+  if (TYPE_PATTERNS.VEC_U8.test(normalized)) return 'ScaleBytes';
+  if (TYPE_PATTERNS.FIXED_U8_ARRAY.test(normalized)) return 'ScaleFixedBytes';
+
+  // Fallback: assume user-defined type has a matching codec
+  // Note: This would need to be the sanitized PascalCase type name in practice
+  return normalized;
+}
+
+/**
+ * Converts a Rust type reference to a safe identifier for encoder function names.
+ * Handles special characters and nested types to create valid Solidity identifiers.
+ * 
+ * @param rustType - Rust type reference
+ * @returns Sanitized type string safe for use in function names
+ * 
+ * @example
+ * sanitizeTypeForEncoder("u32") // returns "U32"
+ * sanitizeTypeForEncoder("Vec<u32>") // returns "Vec_U32"
+ * sanitizeTypeForEncoder("[AccountId32; 10]") // returns "Arr_AccountId32_10"
+ */
+export function sanitizeTypeForEncoder(t: string): string {
+  return t
+    .replace(/\s+/g, '')
+    .replace(/\[/g, 'Arr_')
+    .replace(/]/g, '')
+    .replace(/;/g, '_')
+    .replace(/</g, '_')
+    .replace(/>/g, '')
+    .replace(/,/g, '_')
+    .replace(/u(\d+)/g, 'U$1')
+    .replace(/i(\d+)/g, 'I$1');
+}


### PR DESCRIPTION
Refactor and document the struct type utilities for generating Solidity code from Substrate metadata. It introduces clear type definitions, constants for type mapping, regex patterns for type detection, and improves helper functions for field extraction and type conversion. The code is now more maintainable and easier to extend, with detailed comments explaining each part. Potential bugs marked with "//!".